### PR TITLE
Switch PLL_Language::$home_url to PLL_Language::get_home_url()

### DIFF
--- a/includes/elementor-assets.php
+++ b/includes/elementor-assets.php
@@ -61,8 +61,8 @@ class ElementorAssets {
 			$this->all_domains[] = wp_parse_url( $domain, PHP_URL_HOST );
 		}
 
-		$this->current_domain = $current_language->home_url;
-		$this->default_domain = $default_language->home_url;
+		$this->current_domain = $current_language->get_home_url();
+		$this->default_domain = $default_language->get_home_url();
 
 		// Add filters.
 		add_filter( 'script_loader_src', array( $this, 'translate_url' ) );

--- a/includes/finder/polylang-category.php
+++ b/includes/finder/polylang-category.php
@@ -90,7 +90,7 @@ class PolylangCategory extends Base_Category {
 
 			$items[ 'website-language-' . $lang_data->slug ] = array(
 				'title'       => $lang_data->name,
-				'url'         => esc_url( $lang_data->home_url ),
+				'url'         => esc_url( $lang_data->get_home_url() ),
 				'icon'        => 'eye',
 				'keywords'    => array(
 					'polylang',


### PR DESCRIPTION
PLL_Language::$home_url is deprecated since Polylang 3.4: https://polylang.pro/polylang-3-4-eases-the-translation-of-custom-tables/

I just replaced all occurences with PLL_Language->get_home_url() like the deprication notice advised me to.