### PR TITLE
Elementor Search widget name changed

### DIFF
--- a/includes/connect-plugins.php
+++ b/includes/connect-plugins.php
@@ -590,7 +590,7 @@ class ConnectPlugins {
 	 */
 	public function add_search_form_home_url_filter( $element ) {
 
-		if ( 'search-form' === $element->get_name() ) {
+		if ( 'search' === $element->get_name() ) {
 			add_filter( 'home_url', array( $this, 'search_form_home_url_filter' ), 10, 2 );
 		}
 
@@ -606,7 +606,7 @@ class ConnectPlugins {
 	 */
 	public function remove_search_form_home_url_filter( $element ) {
 
-		if ( 'search-form' === $element->get_name() ) {
+		if ( 'search' === $element->get_name() ) {
 			remove_filter( 'home_url', array( $this, 'search_form_home_url_filter' ) );
 		}
 


### PR DESCRIPTION
The fix on home url in Search Form widget doesn't trigger, because the Elementor widget name has changed from 'search-form' to 'search'.
This pull request only change the check on the widget name to correctly add and remove the filter on 'home_url' hook in widget rendering.
