### PR TITLE
Use correct textdomain in all translations strings

### DIFF
--- a/includes/connect-plugins.php
+++ b/includes/connect-plugins.php
@@ -463,7 +463,7 @@ class ConnectPlugins {
 			$instances     = $theme_builder->get_conditions_manager()->get_document_instances( $default_post );
 
 			if ( empty( $instances ) ) {
-				$instances = array( 'none' => esc_html__( 'None', 'elementor-pro' ) ); // phpcs:ignore WordPress.WP.I18n
+				$instances = array( 'none' => esc_html__( 'None', 'connect-polylang-elementor' ) );
 			}
 
 			echo '<span style="opacity:.4">' . esc_html( implode( ', ', $instances ) ) . '</span><div class="hidden" aria-hidden="true">';
@@ -691,8 +691,8 @@ class ConnectPlugins {
 						'name'  => "cpel-{$language->slug}",
 						'icon'  => 'eicon-plus',
 						'title' => $use_emojis
-							? sprintf( __( 'Add a translation — %s', 'connect-polylang-elementor' ), cpel_flag_emoji( $language->flag_code ) ) // phpcs:ignore WordPress.WP.I18n
-							: sprintf( __( 'Add a translation in %s', 'polylang' ), $language->name ), // phpcs:ignore WordPress.WP.I18n
+							? sprintf( __( 'Add a translation — %s', 'connect-polylang-elementor' ), cpel_flag_emoji( $language->flag_code ) )
+							: sprintf( __( 'Add a translation in %s', 'connect-polylang-elementor' ), $language->name ),
 						'type'  => 'link',
 						'link'  => $link,
 					);
@@ -701,7 +701,7 @@ class ConnectPlugins {
 
 			$group = array(
 				'name'  => 'cpel',
-				'title' => __( 'Languages', 'polylang' ), // phpcs:ignore WordPress.WP.I18n
+				'title' => __( 'Languages', 'connect-polylang-elementor' ),
 				'items' => $items,
 			);
 
@@ -829,13 +829,13 @@ class ConnectPlugins {
 			$instances     = $theme_builder->get_conditions_manager()->get_document_instances( $default_post );
 
 			if ( empty( $instances ) ) {
-				$instances = array( 'no_instances' => esc_html__( 'No instances', 'elementor-pro' ) ); // phpcs:ignore WordPress.WP.I18n
+				$instances = array( 'no_instances' => esc_html__( 'No instances', 'connect-polylang-elementor' ) );
 				$is_active = false;
 			} else {
 				$is_active = 'publish' === $data['status'];
 			}
 
-			$data['instances'] = array( 'cpel' => sprintf( esc_html__( '(from %s)', 'connect-polylang-elementor' ), strtoupper( $language ) ) ) + $instances; // phpcs:ignore WordPress.WP.I18n
+			$data['instances'] = array( 'cpel' => sprintf( esc_html__( '(from %s)', 'connect-polylang-elementor' ), strtoupper( $language ) ) ) + $instances;
 			$data['isActive']  = $is_active;
 		}
 
@@ -922,7 +922,7 @@ class ConnectPlugins {
 		$document->start_controls_section(
 			'cpel_language_section',
 			array(
-				'label' => esc_html__( 'Languages', 'polylang' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+				'label' => esc_html__( 'Languages', 'connect-polylang-elementor' ),
 				'tab'   => \Elementor\Controls_Manager::TAB_SETTINGS,
 			)
 		);
@@ -971,7 +971,7 @@ class ConnectPlugins {
 				$lang_parts['class'] .= ' add-new';
 				$lang_parts['icon']   = '<i class="eicon-plus"></i>';
 				$lang_parts['href']   = $create_link;
-				$lang_parts['text']   = '<span class="text">' . sprintf( esc_html__( 'Add a translation in %s', 'polylang' ), strtolower( esc_html( $language->name ) ) ) . '</span>';  // phpcs:ignore WordPress.WP.I18n
+				$lang_parts['text']   = '<span class="text">' . sprintf( esc_html__( 'Add a translation in %s', 'connect-polylang-elementor' ), strtolower( esc_html( $language->name ) ) ) . '</span>';
 			}
 
 			$raw_html .= sprintf(

--- a/includes/dynamic-tags/language-flag.php
+++ b/includes/dynamic-tags/language-flag.php
@@ -33,7 +33,7 @@ class LanguageFlag extends Data_Tag {
 		$this->add_control(
 			'language',
 			array(
-				'label'   => __( 'Language', 'polylang' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+				'label'   => __( 'Language', 'connect-polylang-elementor' ),
 				'type'    => Controls_Manager::SELECT,
 				'options' => $options,
 				'default' => 'current',

--- a/includes/dynamic-tags/manager.php
+++ b/includes/dynamic-tags/manager.php
@@ -37,7 +37,7 @@ class Manager {
 	public function register_dynamic_tags( $dynamic_tags ) {
 
 		// Register our tag group.
-		Plugin::instance()->dynamic_tags->register_group( self::TAG_GROUP, array( 'title' => __( 'Languages', 'polylang' ) ) ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+		Plugin::instance()->dynamic_tags->register_group( self::TAG_GROUP, array( 'title' => __( 'Languages', 'connect-polylang-elementor' ) ) );
 
 		// Register the tags.
 		if ( cpel_elementor_min_version( '3.5.0' ) ) {

--- a/includes/dynamic-tags/tag-trait.php
+++ b/includes/dynamic-tags/tag-trait.php
@@ -21,7 +21,7 @@ trait TagTrait {
 		$this->add_control(
 			'language',
 			array(
-				'label'   => __( 'Language', 'polylang' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+				'label'   => __( 'Language', 'connect-polylang-elementor' ),
 				'type'    => Controls_Manager::SELECT,
 				'options' => $options,
 				'default' => 'current',

--- a/includes/finder/polylang-category.php
+++ b/includes/finder/polylang-category.php
@@ -26,7 +26,7 @@ class PolylangCategory extends Base_Category {
 	 */
 	public function get_title() {
 
-		return __( 'Languages', 'polylang' ); // phpcs:ignore WordPress.WP.I18n
+		return __( 'Languages', 'connect-polylang-elementor' );
 
 	}
 

--- a/includes/language-visibility.php
+++ b/includes/language-visibility.php
@@ -73,7 +73,7 @@ class LanguageVisibility {
 			'cpel_lv_enabled',
 			array(
 				'type'           => Controls_Manager::SWITCHER,
-				'label'          => __( 'Enable', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'          => __( 'Enable', 'connect-polylang-elementor' ),
 				'render_type'    => 'template',
 				'prefix_class'   => 'cpel-lv--',
 				'style_transfer' => false,
@@ -83,15 +83,15 @@ class LanguageVisibility {
 		$element->add_control(
 			'cpel_lv_action',
 			array(
-				'label'     => __( 'Visibility', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Visibility', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::CHOOSE,
 				'options'   => array(
 					'show' => array(
-						'title' => __( 'Show', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Show', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-preview-medium',
 					),
 					'hide' => array(
-						'title' => __( 'Hide', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Hide', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-ban',
 					),
 				),

--- a/includes/widgets/polylang-language-switcher.php
+++ b/includes/widgets/polylang-language-switcher.php
@@ -52,7 +52,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 	 */
 	public function get_title() {
 
-		return __( 'Language switcher', 'polylang' ); // phpcs:ignore WordPress.WP.I18n
+		return __( 'Language switcher', 'connect-polylang-elementor' );
 
 	}
 
@@ -165,17 +165,17 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		/** Content: Layout etc. */
 		$this->start_controls_section(
 			'section_content',
-			array( 'label' => __( 'Content', 'elementor' ) ) // phpcs:ignore WordPress.WP.I18n
+			array( 'label' => __( 'Content', 'connect-polylang-elementor' ) )
 		);
 
 		$this->add_control(
 			'layout',
 			array(
-				'label'        => __( 'Layout', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => __( 'Layout', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::SELECT,
 				'options'      => array(
-					'horizontal' => __( 'Horizontal', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
-					'vertical'   => __( 'Vertical', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+					'horizontal' => __( 'Horizontal', 'connect-polylang-elementor' ),
+					'vertical'   => __( 'Vertical', 'connect-polylang-elementor' ),
 					'dropdown'   => __( 'Dropdown', 'connect-polylang-elementor' ),
 				),
 				'default'      => 'horizontal',
@@ -187,23 +187,23 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'align_items',
 			array(
-				'label'        => __( 'Alignment', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => __( 'Alignment', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::CHOOSE,
 				'options'      => array(
 					'left'    => array(
-						'title' => __( 'Left', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Left', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-h-align-left',
 					),
 					'center'  => array(
-						'title' => __( 'Center', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Center', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-h-align-center',
 					),
 					'right'   => array(
-						'title' => __( 'Right', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Right', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-h-align-right',
 					),
 					'justify' => array(
-						'title' => __( 'Stretch', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Stretch', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-h-align-stretch',
 					),
 				),
@@ -214,7 +214,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'hide_current',
 			array(
-				'label'        => __( 'Hides the current language', 'polylang' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => __( 'Hides the current language', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::SWITCHER,
 				'return_value' => 'yes',
 				'default'      => '',
@@ -225,7 +225,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'hide_missing',
 			array(
-				'label'        => __( 'Hides languages with no translation', 'polylang' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => __( 'Hides languages with no translation', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::SWITCHER,
 				'return_value' => 'yes',
 				'default'      => '',
@@ -235,7 +235,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'show_country_flag',
 			array(
-				'label'        => __( 'Displays flags', 'polylang' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => __( 'Displays flags', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::SWITCHER,
 				'return_value' => 'yes',
 				'default'      => 'yes',
@@ -245,7 +245,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'show_language_name',
 			array(
-				'label'        => __( 'Displays language names', 'polylang' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => __( 'Displays language names', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::SWITCHER,
 				'return_value' => 'yes',
 				'default'      => 'yes',
@@ -277,7 +277,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 
 		$this->start_controls_tab(
 			'tab_menu_item_normal',
-			array( 'label' => __( 'Normal', 'elementor' ) ) // phpcs:ignore WordPress.WP.I18n
+			array( 'label' => __( 'Normal', 'connect-polylang-elementor' ) )
 		);
 
 		$this->add_group_control(
@@ -292,7 +292,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'color_menu_item',
 			array(
-				'label'     => __( 'Text Color', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Text Color', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'global'    => array( 'default' => Global_Colors::COLOR_TEXT ),
 				'default'   => '',
@@ -306,7 +306,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'bg_dropdown_item',
 			array(
-				'label'     => __( 'Background Color', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Background Color', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#FFFFFF',
 				'selectors' => array(
@@ -320,7 +320,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 
 		$this->start_controls_tab(
 			'tab_menu_item_hover',
-			array( 'label' => __( 'Hover', '__elementor' ) ) // phpcs:ignore WordPress.WP.I18n
+			array( 'label' => __( 'Hover', 'connect-polylang-elementor' ) )
 		);
 
 		$this->add_group_control(
@@ -335,7 +335,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'color_menu_item_hover',
 			array(
-				'label'     => __( 'Text Color', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Text Color', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'global'    => array( 'default' => Global_Colors::COLOR_ACCENT ),
 				'selectors' => array(
@@ -347,7 +347,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'bg_dropdown_hover',
 			array(
-				'label'     => __( 'Background Color', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Background Color', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#D9D9D9',
 				'selectors' => array(
@@ -362,7 +362,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->start_controls_tab(
 			'tab_menu_item_active',
 			array(
-				'label'     => __( 'Active', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Active', 'connect-polylang-elementor' ),
 				'condition' => array(
 					'hide_current!' => 'yes',
 					'layout!'       => 'dropdown',
@@ -382,7 +382,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'color_menu_item_active',
 			array(
-				'label'     => __( 'Text Color', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Text Color', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '',
 				'selectors' => array( '{{WRAPPER}} .cpel-switcher__lang--active a' => 'color: {{VALUE}}' ),
@@ -425,7 +425,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_responsive_control(
 			'menu_space_between',
 			array(
-				'label'     => __( 'Space Between', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Space Between', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => array(
 					'px' => array( 'max' => 100 ),
@@ -474,11 +474,11 @@ class PolylangLanguageSwitcher extends Widget_Base {
 				'type'         => Controls_Manager::CHOOSE,
 				'options'      => array(
 					'down' => array(
-						'title' => __( 'Down', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Down', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-arrow-down',
 					),
 					'up'   => array(
-						'title' => __( 'Up', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+						'title' => __( 'Up', 'connect-polylang-elementor' ),
 						'icon'  => 'eicon-arrow-up',
 					),
 				),
@@ -490,7 +490,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'dropdown_icon',
 			array(
-				'label'                  => __( 'Icon', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'                  => __( 'Icon', 'connect-polylang-elementor' ),
 				'type'                   => Controls_Manager::ICONS,
 				'fa4compatibility'       => 'icon',
 				'recommended'            => array(
@@ -514,7 +514,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'dropdown_icon_indent',
 			array(
-				'label'     => __( 'Icon Spacing', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Icon Spacing', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => array(
 					'px' => array( 'max' => 50 ),
@@ -536,7 +536,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->start_controls_section(
 			'country_flag_section',
 			array(
-				'label'     => __( 'Flag', 'polylang' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Flag', 'connect-polylang-elementor' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => array( 'show_country_flag' => 'yes' ),
 			)
@@ -555,7 +555,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'aspect_ratio_flag',
 			array(
-				'label'        => __( 'Aspect Ratio', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => __( 'Aspect Ratio', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::SELECT,
 				'options'      => array(
 					'43' => '4:3',
@@ -570,7 +570,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_responsive_control(
 			'size_flag',
 			array(
-				'label'     => __( 'Size', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Size', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => array(
 					'px' => array( 'min' => 16 ),
@@ -587,7 +587,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_responsive_control(
 			'border_radius_flag',
 			array(
-				'label'      => __( 'Border Radius', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'      => __( 'Border Radius', 'connect-polylang-elementor' ),
 				'type'       => Controls_Manager::SLIDER,
 				'size_units' => array( 'px', '%' ),
 				'range'      => array(
@@ -617,7 +617,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_responsive_control(
 			'text_indent_language_name',
 			array(
-				'label'     => __( 'Text Indent', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Text Indent', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => array(
 					'px' => array( 'max' => 50 ),
@@ -647,7 +647,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'uppercase_language_code',
 			array(
-				'label'        => _x( 'Uppercase', 'Typography Control', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'        => _x( 'Uppercase', 'Typography Control', 'connect-polylang-elementor' ),
 				'type'         => Controls_Manager::SWITCHER,
 				'return_value' => 'yes',
 				'default'      => 'yes',
@@ -657,7 +657,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_responsive_control(
 			'text_indent_language_code',
 			array(
-				'label'     => __( 'Text Indent', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label'     => __( 'Text Indent', 'connect-polylang-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => array(
 					'px' => array( 'max' => 50 ),
@@ -672,7 +672,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'before_language_code',
 			array(
-				'label' => __( 'Before', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label' => __( 'Before', 'connect-polylang-elementor' ),
 				'type'  => Controls_Manager::TEXT,
 			)
 		);
@@ -680,7 +680,7 @@ class PolylangLanguageSwitcher extends Widget_Base {
 		$this->add_control(
 			'after_language_code',
 			array(
-				'label' => __( 'After', 'elementor' ), // phpcs:ignore WordPress.WP.I18n
+				'label' => __( 'After', 'connect-polylang-elementor' ),
 				'type'  => Controls_Manager::TEXT,
 			)
 		);


### PR DESCRIPTION
It's a bad practice to use textdomain from other plugins, and in any case, it doesn't reduces the amount of translation strings  in https://translate.wordpress.org/projects/wp-plugins/connect-polylang-elementor/

This PR adds the correct textdomain in all translations strings.