### PR TITLE
Fix: Elementor Editor Search Ignoring active language

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,13 +199,15 @@ There are quite a few:
 
 ## Changelog
 
-## Version 2.6.0 | 2026-01-16 
-
+## Version 2.6.0 | 2026-06-03 
+* **Fix**: Elementor Editor Search Ignoring active language detected by @aidezmoi [The search function in Elementor editor isn’t working for translations](https://wordpress.org/support/topic/the-search-function-in-elementor-editor-isnt-working-for-translations/#post-18918086)
 * **Added:** New dashboard section with a **Getting Started** page to help users set up the plugin quickly.
 * **Added:** **Floating language switcher designer** to customize the language switcher visually, without coding.
 * **Added:** AutoPoly promotional admin notice.
 * **Improved:** Overall onboarding experience for first-time users.
 * **Improved:** Language switcher design and placement for better usability.
+* **Compatibility:** Elementor v4.1.1 and Polylang v3.8.4.
+* **Improved:** Minor code Improvements.
 
 ## 2.5.5 
 * Tweaks: Enhanced editor language switcher control

--- a/README.txt
+++ b/README.txt
@@ -208,14 +208,14 @@ Please report security bugs found in the source code of the undefined plugin thr
 
 == Changelog ==
 
-= Version 2.6.0 | 2026-01-19 =
-
+= Version 2.6.0 | 2026-06-03 =
+* **Fix**: Elementor Editor Search Ignoring active language detected by @aidezmoi [The search function in Elementor editor isn’t working for translations](https://wordpress.org/support/topic/the-search-function-in-elementor-editor-isnt-working-for-translations/#post-18918086)
 * **Added:** New dashboard section with a **Getting Started** page to help users set up the plugin quickly.
 * **Added:** **Floating language switcher designer** to customize the language switcher visually, without coding.
 * **Added:** AutoPoly promotional admin notice.
 * **Improved:** Overall onboarding experience for first-time users.
 * **Improved:** Language switcher design and placement for better usability.
-* **Compatibility:** Elementor v3.34.1 and Polylang v3.7.6.
+* **Compatibility:** Elementor v4.1.1 and Polylang v3.8.4.
 * **Improved:** Minor code Improvements.
 
 = 2.5.5 =

--- a/connect-polylang-elementor.php
+++ b/connect-polylang-elementor.php
@@ -20,8 +20,8 @@
  * Requires WP:       5.4
  * Requires PHP:      5.6
  * Requires Plugins:  polylang, elementor
- * Elementor tested up to: 3.34.1
- * Elementor Pro tested up to: 3.34.1
+ * Elementor tested up to:4.1.1
+ * Elementor Pro tested up to: 4.1.1
  *
  * Copyright (c) 2021 Paco Toledo - CREAME
  * Copyright (c) 2018-2021 David Decker - DECKERWEB

--- a/includes/connect-plugins.php
+++ b/includes/connect-plugins.php
@@ -58,6 +58,9 @@ class ConnectPlugins {
 			// All langs for template conditions & global widgets.
 			add_action( 'parse_query', array( $this, 'query_all_languages' ), 1 );
 
+			// Elementor editor term search (categories, tags, etc.).
+			add_filter( 'get_terms_args', array( $this, 'elementor_editor_terms_lang' ), 20, 2 );
+
 			// Empty template conditions on translations.
 			add_filter( 'get_post_metadata', array( $this, 'elementor_conditions_empty_on_translations' ), 10, 3 );
 			add_filter( 'pre_update_option_elementor_pro_theme_builder_conditions', array( $this, 'theme_builder_conditions_remove_empty' ) );
@@ -139,7 +142,10 @@ class ConnectPlugins {
 	}
 
 	/**
-	 * Query all languages if conditions meets
+	 * Adjust Polylang language filtering for Elementor admin queries.
+	 *
+	 * - Theme Builder conditions & global widgets: all languages.
+	 * - Elementor editor searches (posts, templates, loop items): edited document language.
 	 *
 	 *   Note: Needs to be priority 1, since Polylang uses the action parse_query
 	 *         which is fired before 'pre_get_posts'.
@@ -169,7 +175,86 @@ class ConnectPlugins {
 
 		if ( $is_elementor_conditions || $is_global_widget ) {
 			$query->set( 'lang', '' );
+			return;
 		}
+
+		$lang = cpel_get_elementor_editor_language();
+
+		if ( ! $lang || ! $this->should_filter_elementor_editor_post_query( $query ) ) {
+			return;
+		}
+
+		$query->set( 'lang', $lang );
+
+	}
+
+	/**
+	 * Whether a WP_Query in the Elementor editor should use the edited document's language.
+	 *
+	 * @since 2.5.6
+	 *
+	 * @param \WP_Query $query Current query.
+	 * @return bool
+	 */
+	private function should_filter_elementor_editor_post_query( $query ) {
+
+		// Do not restrict when loading already-selected post IDs.
+		if ( ! empty( $query->query_vars['post__in'] ) ) {
+			return false;
+		}
+
+		$post_type = $query->get( 'post_type' );
+
+		if ( empty( $post_type ) ) {
+			return false;
+		}
+
+		foreach ( (array) $post_type as $type ) {
+			if ( 'any' === $type || pll_is_translated_post_type( $type ) ) {
+				return true;
+			}
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Filter taxonomy term searches in the Elementor editor by the edited document's language.
+	 *
+	 * @since 2.5.6
+	 *
+	 * @param array        $args       WP_Term_Query arguments.
+	 * @param string|array $taxonomies Queried taxonomies.
+	 * @return array
+	 */
+	public function elementor_editor_terms_lang( $args, $taxonomies ) {
+
+		if ( ! empty( $args['object_ids'] ) ) {
+			return $args;
+		}
+
+		// Do not restrict when loading already-selected term IDs.
+		if ( empty( $args['search'] ) && empty( $args['name__like'] ) ) {
+			if ( ! empty( $args['include'] ) || ! empty( $args['exclude'] ) || ! empty( $args['term_taxonomy_id'] ) ) {
+				return $args;
+			}
+		}
+
+		$lang = cpel_get_elementor_editor_language();
+
+		if ( ! $lang ) {
+			return $args;
+		}
+
+		foreach ( (array) $taxonomies as $taxonomy ) {
+			if ( pll_is_translated_taxonomy( $taxonomy ) ) {
+				$args['lang'] = $lang;
+				break;
+			}
+		}
+
+		return $args;
 
 	}
 

--- a/includes/connect-plugins.php
+++ b/includes/connect-plugins.php
@@ -451,7 +451,7 @@ class ConnectPlugins {
 
 		if ( $sub_id && cpel_is_translation( $this->template_id ) ) {
 
-			if ( in_array( $parsed_condition['sub_name'], get_post_types(), true ) ) {
+			if ( get_post_type( $sub_id ) ) {
 
 				$sub_id = pll_get_post( $sub_id ) ?: $sub_id; //phpcs:ignore WordPress.PHP.DisallowShortTernary
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -114,6 +114,43 @@ function cpel_is_elementor_editor() {
 }
 
 /**
+ * Post ID of the document open in the Elementor editor (page load or AJAX).
+ *
+ * @since 2.5.6
+ *
+ * @return int Post ID, or 0 if not in the Elementor editor context.
+ */
+function cpel_get_elementor_editor_post_id() {
+
+	if ( cpel_is_elementor_editor() ) {
+		return absint( $_GET['post'] );
+	}
+
+	if ( wp_doing_ajax() && isset( $_REQUEST['action'], $_REQUEST['editor_post_id'] )
+		&& 'elementor_ajax' === sanitize_key( wp_unslash( $_REQUEST['action'] ) ) ) {
+		return absint( $_REQUEST['editor_post_id'] );
+	}
+
+	return 0;
+
+}
+
+/**
+ * Polylang language slug for the document open in the Elementor editor.
+ *
+ * @since 2.5.6
+ *
+ * @return string Language slug, or empty string if unknown.
+ */
+function cpel_get_elementor_editor_language() {
+
+	$post_id = cpel_get_elementor_editor_post_id();
+
+	return $post_id ? (string) pll_get_post_language( $post_id ) : '';
+
+}
+
+/**
  * Is post a translation in secondary language
  *
  * @since  2.0.0


### PR DESCRIPTION

Fixes an issue where searching for templates or terms in the Elementor editor only returned results from the **default language**, ignoring the active language translation .

* **Language-Scoped Search:** Filters template, post, and term search queries by the current editor language.
* **Safe Exemptions:** Leaves global widgets, theme conditions, and explicit ID queries untouched.


* **Reported by:** `@aidezmoi` on WP.org.
* **Reference:** [The search function in Elementor editor isn’t working for translations](https://wordpress.org/support/topic/the-search-function-in-elementor-editor-isnt-working-for-translations/#post-18918086)